### PR TITLE
Add Namespaces of Custom Metrics

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -32,9 +32,10 @@ type DataSource struct {
 
 // JSONData is a representation of the datasource `jsonData` property
 type JSONData struct {
-	AssumeRoleArn string `json:"assumeRoleArn,omitempty"`
-	AuthType      string `json:"authType,omitempty"`
-	DefaultRegion string `json:"defaultRegion,omitempty"`
+	AssumeRoleArn           string `json:"assumeRoleArn,omitempty"`
+	AuthType                string `json:"authType,omitempty"`
+	CustomMetricsNamespaces string `json:"customMetricsNamespaces,omitempty"`
+	DefaultRegion           string `json:"defaultRegion,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -46,9 +46,10 @@ func TestNewDataSource(t *testing.T) {
 		Access:    "access",
 		IsDefault: true,
 		JSONData: JSONData{
-			AssumeRoleArn: "arn:aws:iam::123:role/some-role",
-			AuthType:      "keys",
-			DefaultRegion: "us-east-1",
+			AssumeRoleArn:           "arn:aws:iam::123:role/some-role",
+			AuthType:                "keys",
+			CustomMetricsNamespaces: "SomeNamespace",
+			DefaultRegion:           "us-east-1",
 		},
 		SecureJSONData: SecureJSONData{
 			AccessKey: "123",


### PR DESCRIPTION
Add support for Cloudwatch namespaces of custom metrics:
https://github.com/grafana/grafana/blob/master/docs/sources/administration/provisioning.md#json-data