### PR TITLE
Implement skipping TLS certificate verification for datasource.

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -36,6 +36,7 @@ type JSONData struct {
 	AuthType                string `json:"authType,omitempty"`
 	CustomMetricsNamespaces string `json:"customMetricsNamespaces,omitempty"`
 	DefaultRegion           string `json:"defaultRegion,omitempty"`
+	TlsSkipVerify           bool   `json:"tlsSkipVerify,omitempty"`
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -54,6 +54,7 @@ func TestNewDataSource(t *testing.T) {
 			AuthType:                "keys",
 			CustomMetricsNamespaces: "SomeNamespace",
 			DefaultRegion:           "us-east-1",
+			TlsSkipVerify:           true,
 		},
 		SecureJSONData: SecureJSONData{
 			AccessKey: "123",


### PR DESCRIPTION
The Grafana HTTP API allows us to set skipping TLS verification for datasources. This wasn't yet implemented in the go-grafana-api but I believe some people will benefit from it.

Our use case: 
While using the Grafana Terraform provider (https://github.com/terraform-providers/terraform-provider-grafana) we found that we couldn't set "Skip TLS Verification (Insecure)" which was required on a TLS-enabled datasource with a self-signed certificate (Prometheus behind NGINX).

This would of course require a PR to terraform-provider-grafana as well, which I plan to do once this is figured out.