### PR TITLE
Add Error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	ErrNotFound = errors.New("Resources Not Found")
+	ErrNotFound = errors.New("404 Not Found")
 )
 
 type Client struct {


### PR DESCRIPTION
Hello,

I added this PR because it's painfull to write code like this: 
```
dashboard, err := client.Dashboard(slug)
if err != nil && err.Error() == "404 Not Found" {
}
```

Now here is the better way:
```
dashboard, err := client.Dashboard(slug)
if err == gapi.ErrNotFound {
}
```

Added the `sendRequest` func because there are so many duplicated code such as:
```
         resp, err := c.Do(req)
	if err != nil {
		return nil, err
	}
	if resp.StatusCode != 200 {
		data, _ = ioutil.ReadAll(resp.Body)
		return nil, fmt.Errorf("status: %d, body: %s", resp.StatusCode, data)
	}

	data, err = ioutil.ReadAll(resp.Body)
	if err != nil {
		return nil, err
	}
```

Also, the `sendRequest` func included the response body when HTTP Code is not 200, which is very useful when comes to debugging.
