### PR TITLE
Set new HttpClient via cleanhttp

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 type Client struct {
@@ -35,7 +37,7 @@ func New(auth, baseURL string) (*Client, error) {
 	return &Client{
 		key,
 		*u,
-		&http.Client{},
+		cleanhttp.DefaultClient(),
 	}, nil
 }
 


### PR DESCRIPTION
The default `http.Client` when initialized like this does not have any Transport/RoundTripper, which prevents users of this library downstream from adding custom transports on top, e.g. [logging transport we have in Terraform](https://github.com/hashicorp/terraform/blob/eda878354d2814ed8430262df288df8d4604df71/helper/logging/transport.go#L12-L46).

We would like to use it [in the Grafana provider](https://github.com/terraform-providers/terraform-provider-grafana/pull/46), but any request then blows up due to Transport being `nil` and I think it's better to avoid just blindly setting default transport when adding a new one.