### PR TITLE
Implementation of Folder Permissions API

### DIFF
--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -1,0 +1,88 @@
+package gapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+// FolderPermission has information such as a folder, user, team, role and permission.
+type FolderPermission struct {
+	Id        int64  `json:"id"`
+	FolderUid string `json:"uid"`
+	UserId    int64  `json:"userId"`
+	TeamId    int64  `json:"teamId"`
+	Role      string `json:"role"`
+	IsFolder  bool   `json:"isFolder"`
+
+	// Permission levels are
+	// 1 = View
+	// 2 = Edit
+	// 4 = Admin
+	Permission     int64  `json:"permission"`
+	PermissionName string `json:"permissionName"`
+
+	// optional fields
+	FolderId    int64 `json:"folderId,omitempty"`
+	DashboardId int64 `json:"dashboardId,omitempty"`
+}
+
+type PermissionItems struct {
+	Items []PermissionItem `json:"items"`
+}
+
+type PermissionItem struct {
+	// As you can see the docs, each item has a pair of [Role|TeamId|UserId] and Permission.
+	// unnecessary fields are omitted.
+	Role       string `json:"role,omitempty"`
+	TeamId     int64  `json:"teamId,omitempty"`
+	UserId     int64  `json:"userId,omitempty"`
+	Permission int64  `json:"permission"`
+}
+
+func (c *Client) FolderPermissions(fid string) ([]FolderPermission, error) {
+	permissions := make([]FolderPermission, 0)
+
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil)
+	if err != nil {
+		return permissions, err
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return permissions, err
+	}
+	if resp.StatusCode != 200 {
+		return permissions, fmt.Errorf(resp.Status)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return permissions, err
+	}
+	if err := json.Unmarshal(data, &permissions); err != nil {
+		return permissions, err
+	}
+	return permissions, nil
+}
+
+// UpdateFolderPermissions remove existing permissions if items are not included in the request.
+func (c *Client) UpdateFolderPermissions(fid string, items *PermissionItems) error {
+	path := fmt.Sprintf("/api/folders/%s/permissions", fid)
+	data, err := json.Marshal(items)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest("POST", path, nil, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf(resp.Status)
+	}
+	return nil
+}

--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -29,7 +29,7 @@ type FolderPermission struct {
 }
 
 type PermissionItems struct {
-	Items []PermissionItem `json:"items"`
+	Items []*PermissionItem `json:"items"`
 }
 
 type PermissionItem struct {
@@ -41,8 +41,8 @@ type PermissionItem struct {
 	Permission int64  `json:"permission"`
 }
 
-func (c *Client) FolderPermissions(fid string) ([]FolderPermission, error) {
-	permissions := make([]FolderPermission, 0)
+func (c *Client) FolderPermissions(fid string) ([]*FolderPermission, error) {
+	permissions := make([]*FolderPermission, 0)
 
 	req, err := c.newRequest("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil)
 	if err != nil {

--- a/folder_permissions_test.go
+++ b/folder_permissions_test.go
@@ -1,0 +1,134 @@
+package gapi
+
+import (
+	"github.com/gobs/pretty"
+	"testing"
+)
+
+const (
+	getFolderPermissionsJSON = `
+[
+  {
+    "id": 1,
+    "folderId": -1,
+    "created": "2017-06-20T02:00:00+02:00",
+    "updated": "2017-06-20T02:00:00+02:00",
+    "userId": 0,
+    "userLogin": "",
+    "userEmail": "",
+    "teamId": 0,
+    "team": "",
+    "role": "Viewer",
+    "permission": 1,
+    "permissionName": "View",
+    "uid": "nErXDvCkzz",
+    "title": "",
+    "slug": "",
+    "isFolder": false,
+    "url": ""
+  },
+  {
+    "id": 2,
+    "dashboardId": -1,
+    "created": "2017-06-20T02:00:00+02:00",
+    "updated": "2017-06-20T02:00:00+02:00",
+    "userId": 0,
+    "userLogin": "",
+    "userEmail": "",
+    "teamId": 0,
+    "team": "",
+    "role": "Editor",
+    "permission": 2,
+    "permissionName": "Edit",
+    "uid": "",
+    "title": "",
+    "slug": "",
+    "isFolder": false,
+    "url": ""
+  }
+]
+`
+	updateFolderPermissionsJSON = `
+{
+	"message": "Folder permissions updated"
+}
+`
+)
+
+func TestFolderPermissions(t *testing.T) {
+	server, client := gapiTestTools(200, getFolderPermissionsJSON)
+	defer server.Close()
+
+	fid := "nErXDvCkzz"
+	resp, err := client.FolderPermissions(fid)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(pretty.PrettyFormat(resp))
+
+	expects := []FolderPermission{
+		{
+			Id:             1,
+			FolderUid:      "nErXDvCkzz",
+			UserId:         0,
+			TeamId:         0,
+			Role:           "Viewer",
+			IsFolder:       false,
+			Permission:     1,
+			PermissionName: "View",
+			FolderId:       -1,
+			DashboardId:    0,
+		},
+		{
+			Id:             2,
+			FolderUid:      "",
+			UserId:         0,
+			TeamId:         0,
+			Role:           "Editor",
+			IsFolder:       false,
+			Permission:     2,
+			PermissionName: "Edit",
+			FolderId:       0,
+			DashboardId:    -1,
+		},
+	}
+
+	for i, expect := range expects {
+		t.Run("check data", func(t *testing.T) {
+			if resp[i] != expect {
+				t.Error("Not correctly data")
+			}
+		})
+	}
+}
+
+func TestUpdateFolderPermissions(t *testing.T) {
+	server, client := gapiTestTools(200, updateFolderPermissionsJSON)
+	defer server.Close()
+
+	items := &PermissionItems{
+		Items: []PermissionItem{
+			{
+				Role:       "viewer",
+				Permission: 1,
+			},
+			{
+				Role:       "Editor",
+				Permission: 2,
+			},
+			{
+				TeamId:     1,
+				Permission: 1,
+			},
+			{
+				UserId:     11,
+				Permission: 4,
+			},
+		},
+	}
+	err := client.UpdateFolderPermissions("nErXDvCkzz", items)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/folder_permissions_test.go
+++ b/folder_permissions_test.go
@@ -67,7 +67,7 @@ func TestFolderPermissions(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	expects := []FolderPermission{
+	expects := []*FolderPermission{
 		{
 			Id:             1,
 			FolderUid:      "nErXDvCkzz",
@@ -96,7 +96,7 @@ func TestFolderPermissions(t *testing.T) {
 
 	for i, expect := range expects {
 		t.Run("check data", func(t *testing.T) {
-			if resp[i] != expect {
+			if resp[i].Id != expect.Id || resp[i].Role != expect.Role {
 				t.Error("Not correctly data")
 			}
 		})
@@ -108,7 +108,7 @@ func TestUpdateFolderPermissions(t *testing.T) {
 	defer server.Close()
 
 	items := &PermissionItems{
-		Items: []PermissionItem{
+		Items: []*PermissionItem{
 			{
 				Role:       "viewer",
 				Permission: 1,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nytm/go-grafana-api
 
-go 1.12
+go 1.13
 
 require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nytm/go-grafana-api
 
-go 1.13
+go 1.12
 
 require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b


### PR DESCRIPTION
This PR implements grafana [Folder Permissions API](https://grafana.com/docs/grafana/latest/http_api/folder_permissions/).
[terraform-providers/terraform-provider-grafana/issues/51](https://github.com/terraform-providers/terraform-provider-grafana/issues/51) requires [Team API](https://grafana.com/docs/grafana/latest/http_api/team/) and [Folder Permissions](https://grafana.com/docs/grafana/latest/http_api/folder_permissions/)

I implemented it for the first steps to solve the above issue.