### PR TITLE
Allow unauthenticated client

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ func New(auth, baseURL string) (*Client, error) {
 	if strings.Contains(auth, ":") {
 		split := strings.Split(auth, ":")
 		u.User = url.UserPassword(split[0], split[1])
-	} else {
+	} else if auth != "" {
 		key = fmt.Sprintf("Bearer %s", auth)
 	}
 	return &Client{


### PR DESCRIPTION
Currently `New(auth, baseURL)` accepts two types of values for `auth`:
1. a string containing a `:` which is interpreted as `user:password`
2. any other string is interpreted as a Bearer token

This PR adds a third possibility: an empty string indicating that no authentication should be performed.