### PR TITLE
Support basic authentication with passwords that contain a colon

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,7 +29,7 @@ func New(auth, baseURL string) (*Client, error) {
 	}
 	key := ""
 	if strings.Contains(auth, ":") {
-		split := strings.Split(auth, ":")
+		split := strings.SplitN(auth, ":", 2)
 		u.User = url.UserPassword(split[0], split[1])
 	} else {
 		key = fmt.Sprintf("Bearer %s", auth)


### PR DESCRIPTION
Currently basic authentication fails if the password contains a `:`, because only the characters before the colon will be used as password.

This PR fixes this.

See also:
- https://golang.org/pkg/strings/#SplitN
- https://play.golang.org/p/w1D47HPwCLf