### PR TITLE
Add Stackdriver datasource config options

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -78,6 +78,13 @@ type JSONData struct {
 	// Used by Prometheus
 	HttpMethod   string `json:"httpMethod,omitempty"`
 	QueryTimeout string `json:"queryTimeout,omitempty"`
+	
+	// Used by Stackdriver
+	AuthenticationType string `json:"authenticationType,omitempty"`
+	ClientEmail 	   string `json:"clientEmail,omitempty"`
+	DefaultProject     string `json:"defaultProject,omitempty"`
+	TokenUri 	   string `json:"tokenUri,omitempty"`
+	
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property
@@ -92,6 +99,9 @@ type SecureJSONData struct {
 	// Used by Cloudwatch
 	AccessKey string `json:"accessKey,omitempty"`
 	SecretKey string `json:"secretKey,omitempty"`
+	
+	// Used by Stackdriver
+	PrivateKey string `json:"privateKey,omitempty"`
 }
 
 func (c *Client) NewDataSource(s *DataSource) (int64, error) {

--- a/datasource.go
+++ b/datasource.go
@@ -84,7 +84,6 @@ type JSONData struct {
 	ClientEmail 	   string `json:"clientEmail,omitempty"`
 	DefaultProject     string `json:"defaultProject,omitempty"`
 	TokenUri 	   string `json:"tokenUri,omitempty"`
-	
 }
 
 // SecureJSONData is a representation of the datasource `secureJsonData` property


### PR DESCRIPTION
Per #29, it was pointed out that Stackdriver datasource config options aren't available.

These were added based on [Grafana's docs for Stackdriver datasources](https://grafana.com/docs/grafana/latest/features/datasources/stackdriver/#configure-the-data-source-with-provisioning)

---
Resolves #29