### PR TITLE
Deprecate UID funcs

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -48,7 +48,8 @@ type Dashboard struct {
 	Overwrite bool                   `json:"overwrite"`
 }
 
-// Deprecated: use NewDashboard instead
+// SaveDashboard.
+// Deprecated: Use NewDashboard instead.
 func (c *Client) SaveDashboard(model map[string]interface{}, overwrite bool) (*DashboardSaveResponse, error) {
 	wrapper := map[string]interface{}{
 		"dashboard": model,
@@ -137,11 +138,18 @@ func (c *Client) Dashboards() ([]DashboardSearchResponse, error) {
 	return dashboards, err
 }
 
-// Deprecated: Starting from Grafana v5.0. Please update to use DashboardByUID instead.
+func (c *Client) DashboardByUid(uid string) (*Dashboard, error) {
+	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
+}
+
+// Dashboard.
+// Deprecated: Starting from Grafana v5.0. Use DashboardByUid instead.
 func (c *Client) Dashboard(slug string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
+// DashboardByUID.
+// Deprecated: Interface typo. Use DashboardByUid instead.
 func (c *Client) DashboardByUID(uid string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }
@@ -174,11 +182,18 @@ func (c *Client) dashboard(path string) (*Dashboard, error) {
 	return result, err
 }
 
-// Deprecated: Starting from Grafana v5.0. Please update to use DeleteDashboardByUID instead.
+func (c *Client) DeleteDashboardByUid(uid string) error {
+	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
+}
+
+// DeleteDashboard
+// Deprecated: Starting from Grafana v5.0. Use DeleteDashboardByUid instead.
 func (c *Client) DeleteDashboard(slug string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
+// DeleteDashboardByUID
+// Deprecated: Interface typo. Use DeleteDashboardByUid instead.
 func (c *Client) DeleteDashboardByUID(uid string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }

--- a/dashboard.go
+++ b/dashboard.go
@@ -140,13 +140,13 @@ func (c *Client) DashboardByUid(uid string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }
 
-// Dashboard.
+// Dashboard will be removed.
 // Deprecated: Starting from Grafana v5.0. Use DashboardByUid instead.
 func (c *Client) Dashboard(slug string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
-// DashboardByUID.
+// DashboardByUID will be removed.
 // Deprecated: Interface typo. Use DashboardByUid instead.
 func (c *Client) DashboardByUID(uid string) (*Dashboard, error) {
 	return c.dashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
@@ -182,13 +182,13 @@ func (c *Client) DeleteDashboardByUid(uid string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))
 }
 
-// DeleteDashboard
+// DeleteDashboard will be removed.
 // Deprecated: Starting from Grafana v5.0. Use DeleteDashboardByUid instead.
 func (c *Client) DeleteDashboard(slug string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/db/%s", slug))
 }
 
-// DeleteDashboardByUID
+// DeleteDashboardByUID will be removed.
 // Deprecated: Interface typo. Use DeleteDashboardByUid instead.
 func (c *Client) DeleteDashboardByUID(uid string) error {
 	return c.deleteDashboard(fmt.Sprintf("/api/dashboards/uid/%s", uid))

--- a/dashboard.go
+++ b/dashboard.go
@@ -6,9 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/url"
-	"os"
 )
 
 type DashboardMeta struct {
@@ -176,9 +174,7 @@ func (c *Client) dashboard(path string) (*Dashboard, error) {
 	result := &Dashboard{}
 	err = json.Unmarshal(data, &result)
 	result.Folder = result.Meta.Folder
-	if os.Getenv("GF_LOG") != "" {
-		log.Printf("got back dashboard response  %s", data)
-	}
+
 	return result, err
 }
 

--- a/dashboard_test.go
+++ b/dashboard_test.go
@@ -89,7 +89,7 @@ func TestDashboardGet(t *testing.T) {
 		t.Errorf("Invalid uid - %s, Expected %s", uid, "cIBgcSjkk")
 	}
 
-	resp, err = client.DashboardByUID("cIBgcSjkk")
+	resp, err = client.DashboardByUid("cIBgcSjkk")
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,7 +105,7 @@ func TestDashboardGet(t *testing.T) {
 			t.Errorf("%d not detected", code)
 		}
 
-		_, err = client.DashboardByUID("cIBgcSjkk")
+		_, err = client.DashboardByUid("cIBgcSjkk")
 		if err == nil {
 			t.Errorf("%d not detected", code)
 		}
@@ -121,7 +121,7 @@ func TestDashboardDelete(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = client.DeleteDashboardByUID("cIBgcSjkk")
+	err = client.DeleteDashboardByUid("cIBgcSjkk")
 	if err != nil {
 		t.Error(err)
 	}
@@ -134,7 +134,7 @@ func TestDashboardDelete(t *testing.T) {
 			t.Errorf("%d not detected", code)
 		}
 
-		err = client.DeleteDashboardByUID("cIBgcSjkk")
+		err = client.DeleteDashboardByUid("cIBgcSjkk")
 		if err == nil {
 			t.Errorf("%d not detected", code)
 		}

--- a/datasource.go
+++ b/datasource.go
@@ -17,7 +17,7 @@ type DataSource struct {
 
 	Database string `json:"database,omitempty"`
 	User     string `json:"user,omitempty"`
-	// Deprecated in favor of secureJsonData.password
+	// Deprecated: Use secureJsonData.password instead.
 	Password string `json:"password,omitempty"`
 
 	OrgId     int64 `json:"orgId,omitempty"`
@@ -25,7 +25,7 @@ type DataSource struct {
 
 	BasicAuth     bool   `json:"basicAuth"`
 	BasicAuthUser string `json:"basicAuthUser,omitempty"`
-	// Deprecated in favor of secureJsonData.basicAuthPassword
+	// Deprecated: Use secureJsonData.basicAuthPassword instead.
 	BasicAuthPassword string `json:"basicAuthPassword,omitempty"`
 
 	JSONData       JSONData       `json:"jsonData,omitempty"`


### PR DESCRIPTION
In this and the terraform repo there are no uses of ID or UID, better keep it consistent.
https://golang.org/search?q=Deprecated%3A