### PR TITLE
add Annotation method to get an annotation

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -62,6 +62,29 @@ func (c *Client) Annotations(params url.Values) ([]Annotation, error) {
 	return result, err
 }
 
+// Annotation fetches the annotation queried with the ID and params it's passed.
+// It returns an error if no annotation with a matching ID is found.
+func (c *Client) Annotation(id int64, params url.Values) (Annotation, error) {
+	anno := Annotation{}
+	as, err := c.Annotations(params)
+	if err != nil {
+		return Annotation{}, err
+	}
+
+	for _, a := range as {
+		if a.ID == id {
+			anno = a
+			break
+		}
+	}
+
+	if anno.ID == 0 {
+		return anno, fmt.Errorf("annotation %v not found", id)
+	}
+
+	return anno, nil
+}
+
 // NewAnnotation creates a new annotation with the Annotation it is passed
 func (c *Client) NewAnnotation(a *Annotation) (int64, error) {
 	data, err := json.Marshal(a)

--- a/annotation.go
+++ b/annotation.go
@@ -65,7 +65,6 @@ func (c *Client) Annotations(params url.Values) ([]Annotation, error) {
 // Annotation fetches the annotation queried with the ID and params it's passed.
 // It returns an error if no annotation with a matching ID is found.
 func (c *Client) Annotation(id int64, params url.Values) (Annotation, error) {
-	anno := Annotation{}
 	as, err := c.Annotations(params)
 	if err != nil {
 		return Annotation{}, err
@@ -73,16 +72,11 @@ func (c *Client) Annotation(id int64, params url.Values) (Annotation, error) {
 
 	for _, a := range as {
 		if a.ID == id {
-			anno = a
-			break
+			return a, nil
 		}
 	}
 
-	if anno.ID == 0 {
-		return anno, fmt.Errorf("annotation %v not found", id)
-	}
-
-	return anno, nil
+	return Annotation{}, fmt.Errorf("annotation %v not found", id)
 }
 
 // NewAnnotation creates a new annotation with the Annotation it is passed

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -27,6 +27,25 @@ const (
 			"tag2"
 		],
 		"data": {}
+	}, {
+		"id": 1125,
+		"alertId": 0,
+		"dashboardId": 468,
+		"panelId": 2,
+		"userId": 1,
+		"userName": "",
+		"newState": "",
+		"prevState": "",
+		"time": 1507266395000,
+		"text": "test",
+		"metric": "",
+		"regionId": 1123,
+		"type": "event",
+		"tags": [
+			"tag1",
+			"tag2"
+		],
+		"data": {}
 	}]`
 
 	newAnnotationJSON = `{
@@ -65,6 +84,38 @@ func TestAnnotations(t *testing.T) {
 
 	if as[0].ID != 1124 {
 		t.Error("annotations response should contain annotations with an ID")
+	}
+}
+
+func TestAnnotation(t *testing.T) {
+	server, client := gapiTestTools(200, annotationsJSON)
+	defer server.Close()
+
+	a, err := client.Annotation(1124, url.Values{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(pretty.PrettyFormat(a))
+
+	if a.ID != 1124 {
+		t.Error("annotation response should contain the annotation with the correct ID")
+	}
+}
+
+func TestAnnotation_noneFound(t *testing.T) {
+	server, client := gapiTestTools(200, annotationsJSON)
+	defer server.Close()
+
+	a, err := client.Annotation(1, url.Values{})
+	if err.Error() != "annotation 1 not found" {
+		t.Error(err)
+	}
+
+	t.Log(pretty.PrettyFormat(a))
+
+	if a.ID != 0 {
+		t.Error("annotation response should contain an empty annotation when no annotation with a matching ID was found")
 	}
 }
 


### PR DESCRIPTION
This adds a convenience method for fetching an individual
annotation. Note that the [Grafana API](https://grafana.com/docs/grafana/latest/http_api/annotations/)
documentation documents no method for paging through results.

This addresses issue #47 .