### PR TITLE
Centralize request handling

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 // CreateUser creates a Grafana user.
@@ -15,28 +14,19 @@ func (c *Client) CreateUser(user User) (int64, error) {
 		return id, err
 	}
 
-	resp, err := c.request("POST", "/api/admin/users", nil, bytes.NewBuffer(data))
+	created := struct {
+		Id int64 `json:"id"`
+	}{}
+
+	err = c.request("POST", "/api/admin/users", nil, bytes.NewBuffer(data), &created)
 	if err != nil {
 		return id, err
 	}
 
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return id, err
-	}
-	created := struct {
-		Id int64 `json:"id"`
-	}{}
-	err = json.Unmarshal(data, &created)
-	if err != nil {
-		return id, err
-	}
 	return created.Id, err
 }
 
 // DeleteUser deletes a Grafana user.
 func (c *Client) DeleteUser(id int64) error {
-	_, err := c.request("DELETE", fmt.Sprintf("/api/admin/users/%d", id), nil, nil)
-
-	return err
+	return c.request("DELETE", fmt.Sprintf("/api/admin/users/%d", id), nil, nil, nil)
 }

--- a/admin.go
+++ b/admin.go
@@ -3,11 +3,11 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
 
+// CreateUser creates a Grafana user.
 func (c *Client) CreateUser(user User) (int64, error) {
 	id := int64(0)
 	data, err := json.Marshal(user)
@@ -15,17 +15,11 @@ func (c *Client) CreateUser(user User) (int64, error) {
 		return id, err
 	}
 
-	req, err := c.newRequest("POST", "/api/admin/users", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/admin/users", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return id, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return id, err
-	}
-	if resp.StatusCode != 200 {
-		return id, errors.New(resp.Status)
-	}
+
 	data, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return id, err
@@ -40,17 +34,9 @@ func (c *Client) CreateUser(user User) (int64, error) {
 	return created.Id, err
 }
 
+// DeleteUser deletes a Grafana user.
 func (c *Client) DeleteUser(id int64) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/admin/users/%d", id), nil, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err := c.request("DELETE", fmt.Sprintf("/api/admin/users/%d", id), nil, nil)
+
 	return err
 }

--- a/alertnotification.go
+++ b/alertnotification.go
@@ -3,11 +3,11 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
 
+// AlertNotification represents a Grafana alert notification.
 type AlertNotification struct {
 	Id                    int64       `json:"id,omitempty"`
 	Uid                   string      `json:"uid"`
@@ -20,20 +20,13 @@ type AlertNotification struct {
 	Settings              interface{} `json:"settings"`
 }
 
+// AlertNotifications fetches and returns Grafana alert notifications.
 func (c *Client) AlertNotifications() ([]AlertNotification, error) {
 	alertnotifications := make([]AlertNotification, 0)
 
-	req, err := c.newRequest("GET", "/api/alert-notifications/", nil, nil)
+	resp, err := c.request("GET", "/api/alert-notifications/", nil, nil)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -45,19 +38,12 @@ func (c *Client) AlertNotifications() ([]AlertNotification, error) {
 	return alertnotifications, err
 }
 
+// AlertNotification fetches and returns a Grafana alert notification.
 func (c *Client) AlertNotification(id int64) (*AlertNotification, error) {
 	path := fmt.Sprintf("/api/alert-notifications/%d", id)
-	req, err := c.newRequest("GET", path, nil, nil)
+	resp, err := c.request("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -70,22 +56,15 @@ func (c *Client) AlertNotification(id int64) (*AlertNotification, error) {
 	return result, err
 }
 
+// NewAlertNotification creates a new Grafana alert notification.
 func (c *Client) NewAlertNotification(a *AlertNotification) (int64, error) {
 	data, err := json.Marshal(a)
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/alert-notifications", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/alert-notifications", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	if resp.StatusCode != 200 {
-		return 0, errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -100,42 +79,24 @@ func (c *Client) NewAlertNotification(a *AlertNotification) (int64, error) {
 	return result.Id, err
 }
 
+// UpdateAlertNotification updates a Grafana alert notification.
 func (c *Client) UpdateAlertNotification(a *AlertNotification) error {
 	path := fmt.Sprintf("/api/alert-notifications/%d", a.Id)
 	data, err := json.Marshal(a)
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
 
-	return nil
+	return err
+
 }
 
+// DeleteAlertNotification deletes a Grafana alert notification.
 func (c *Client) DeleteAlertNotification(id int64) error {
 	path := fmt.Sprintf("/api/alert-notifications/%d", id)
-	req, err := c.newRequest("DELETE", path, nil, nil)
-	if err != nil {
-		return err
-	}
+	_, err := c.request("DELETE", path, nil, nil)
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
-
-	return nil
+	return err
 }

--- a/annotation.go
+++ b/annotation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -38,18 +37,12 @@ type GraphiteAnnotation struct {
 
 // Annotations fetches the annotations queried with the params it's passed
 func (c *Client) Annotations(params url.Values) ([]Annotation, error) {
-	resp, err := c.request("GET", "/api/annotation", params, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	result := []Annotation{}
-	err = json.Unmarshal(data, &result)
+	err := c.request("GET", "/api/annotation", params, nil, &result)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, err
 }
 
@@ -59,20 +52,16 @@ func (c *Client) NewAnnotation(a *Annotation) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	resp, err := c.request("POST", "/api/annotations", nil, bytes.NewBuffer(data))
-	if err != nil {
-		return 0, err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
 
 	result := struct {
 		ID int64 `json:"id"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err = c.request("POST", "/api/annotations", nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return 0, err
+	}
+
 	return result.ID, err
 }
 
@@ -82,20 +71,16 @@ func (c *Client) NewGraphiteAnnotation(gfa *GraphiteAnnotation) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	resp, err := c.request("POST", "/api/annotations/graphite", nil, bytes.NewBuffer(data))
-	if err != nil {
-		return 0, err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
 
 	result := struct {
 		ID int64 `json:"id"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err = c.request("POST", "/api/annotations/graphite", nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return 0, err
+	}
+
 	return result.ID, err
 }
 
@@ -106,20 +91,16 @@ func (c *Client) UpdateAnnotation(id int64, a *Annotation) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := c.request("PUT", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return "", err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
 
 	result := struct {
 		Message string `json:"message"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err = c.request("PUT", path, nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return "", err
+	}
+
 	return result.Message, err
 }
 
@@ -130,59 +111,45 @@ func (c *Client) PatchAnnotation(id int64, a *Annotation) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	resp, err := c.request("PATCH", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return "", err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
 
 	result := struct {
 		Message string `json:"message"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err = c.request("PATCH", path, nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return "", err
+	}
+
 	return result.Message, err
 }
 
 // DeleteAnnotation deletes the annotation of the ID it is passed
 func (c *Client) DeleteAnnotation(id int64) (string, error) {
 	path := fmt.Sprintf("/api/annotations/%d", id)
-	resp, err := c.request("DELETE", path, nil, bytes.NewBuffer(nil))
-	if err != nil {
-		return "", err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
 	result := struct {
 		Message string `json:"message"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err := c.request("DELETE", path, nil, bytes.NewBuffer(nil), &result)
+	if err != nil {
+		return "", err
+	}
+
 	return result.Message, err
 }
 
 // DeleteAnnotationByRegionID deletes the annotation corresponding to the region ID it is passed
 func (c *Client) DeleteAnnotationByRegionID(id int64) (string, error) {
 	path := fmt.Sprintf("/api/annotations/region/%d", id)
-	resp, err := c.request("DELETE", path, nil, bytes.NewBuffer(nil))
-	if err != nil {
-		return "", err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
 	result := struct {
 		Message string `json:"message"`
 	}{}
-	err = json.Unmarshal(data, &result)
+
+	err := c.request("DELETE", path, nil, bytes.NewBuffer(nil), &result)
+	if err != nil {
+		return "", err
+	}
+
 	return result.Message, err
 }

--- a/annotation.go
+++ b/annotation.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -39,17 +38,9 @@ type GraphiteAnnotation struct {
 
 // Annotations fetches the annotations queried with the params it's passed
 func (c *Client) Annotations(params url.Values) ([]Annotation, error) {
-	req, err := c.newRequest("GET", "/api/annotation", params, nil)
+	resp, err := c.request("GET", "/api/annotation", params, nil)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -68,17 +59,9 @@ func (c *Client) NewAnnotation(a *Annotation) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/annotations", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/annotations", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	if resp.StatusCode != 200 {
-		return 0, errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -99,17 +82,9 @@ func (c *Client) NewGraphiteAnnotation(gfa *GraphiteAnnotation) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/annotations/graphite", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/annotations/graphite", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	if resp.StatusCode != 200 {
-		return 0, errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -131,17 +106,9 @@ func (c *Client) UpdateAnnotation(id int64, a *Annotation) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
+	resp, err := c.request("PUT", path, nil, bytes.NewBuffer(data))
 	if err != nil {
 		return "", err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -163,17 +130,9 @@ func (c *Client) PatchAnnotation(id int64, a *Annotation) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req, err := c.newRequest("PATCH", path, nil, bytes.NewBuffer(data))
+	resp, err := c.request("PATCH", path, nil, bytes.NewBuffer(data))
 	if err != nil {
 		return "", err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -191,17 +150,9 @@ func (c *Client) PatchAnnotation(id int64, a *Annotation) (string, error) {
 // DeleteAnnotation deletes the annotation of the ID it is passed
 func (c *Client) DeleteAnnotation(id int64) (string, error) {
 	path := fmt.Sprintf("/api/annotations/%d", id)
-	req, err := c.newRequest("DELETE", path, nil, bytes.NewBuffer(nil))
+	resp, err := c.request("DELETE", path, nil, bytes.NewBuffer(nil))
 	if err != nil {
 		return "", err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -219,17 +170,9 @@ func (c *Client) DeleteAnnotation(id int64) (string, error) {
 // DeleteAnnotationByRegionID deletes the annotation corresponding to the region ID it is passed
 func (c *Client) DeleteAnnotationByRegionID(id int64) (string, error) {
 	path := fmt.Sprintf("/api/annotations/region/%d", id)
-	req, err := c.newRequest("DELETE", path, nil, bytes.NewBuffer(nil))
+	resp, err := c.request("DELETE", path, nil, bytes.NewBuffer(nil))
 	if err != nil {
 		return "", err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return "", err
-	}
-	if resp.StatusCode != 200 {
-		return "", errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)

--- a/client.go
+++ b/client.go
@@ -59,6 +59,10 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 		return err
 	}
 
+	if os.Getenv("GF_LOG") != "" {
+		log.Printf("response status %d with body %v", resp.StatusCode, string(bodyContents))
+	}
+
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, bodyContents)
 	}

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+// Client is a Grafana API client.
 type Client struct {
 	key     string
 	baseURL url.URL

--- a/client.go
+++ b/client.go
@@ -41,6 +41,24 @@ func New(auth, baseURL string) (*Client, error) {
 	}, nil
 }
 
+func (c *Client) request(method, requestPath string, query url.Values, body io.Reader) (*http.Response, error) {
+	r, err := c.newRequest(method, requestPath, query, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Do(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("status: %d", resp.StatusCode)
+	}
+
+	return resp, err
+}
+
 func (c *Client) newRequest(method, requestPath string, query url.Values, body io.Reader) (*http.Request, error) {
 	url := c.baseURL
 	url.Path = path.Join(url.Path, requestPath)

--- a/client.go
+++ b/client.go
@@ -65,7 +65,7 @@ func (c *Client) request(method, requestPath string, query url.Values, body io.R
 	}
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, bodyContents)
+		return fmt.Errorf("status: %d, body: %v", resp.StatusCode, string(bodyContents))
 	}
 
 	if responseStruct == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,43 @@
+package gapi
+
+import (
+	"testing"
+)
+
+func TestNew_basicAuth(t *testing.T) {
+	c, err := New("user:pass", "http://my-grafana.com")
+	if err != nil {
+		t.Errorf("expected error to be nil; got: %s", err.Error())
+	}
+
+	expected := "http://user:pass@my-grafana.com"
+	if c.baseURL.String() != expected {
+		t.Errorf("expected error: %s; got: %s", expected, c.baseURL.String())
+	}
+}
+
+func TestNew_tokenAuth(t *testing.T) {
+	c, err := New("123", "http://my-grafana.com")
+	if err != nil {
+		t.Errorf("expected error to be nil; got: %s", err.Error())
+	}
+
+	expected := "http://my-grafana.com"
+	if c.baseURL.String() != expected {
+		t.Errorf("expected error: %s; got: %s", expected, c.baseURL.String())
+	}
+
+	expected = "Bearer 123"
+	if c.key != expected {
+		t.Errorf("expected error: %s; got: %s", expected, c.key)
+	}
+}
+
+func TestNew_invalidURL(t *testing.T) {
+	_, err := New("123", "://my-grafana.com")
+
+	expected := "parse ://my-grafana.com: missing protocol scheme"
+	if err.Error() != expected {
+		t.Errorf("expected error: %v; got: %s", expected, err.Error())
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -36,7 +36,7 @@ func TestNew_tokenAuth(t *testing.T) {
 func TestNew_invalidURL(t *testing.T) {
 	_, err := New("123", "://my-grafana.com")
 
-	expected := "parse ://my-grafana.com: missing protocol scheme"
+	expected := "parse \"://my-grafana.com\": missing protocol scheme"
 	if err.Error() != expected {
 		t.Errorf("expected error: %v; got: %s", expected, err.Error())
 	}

--- a/dashboard.go
+++ b/dashboard.go
@@ -14,6 +14,7 @@ type DashboardMeta struct {
 	Folder    int64  `json:"folderId"`
 }
 
+// DashboardSaveResponse represents the Grafana API response to creating or saving a dashboard.
 type DashboardSaveResponse struct {
 	Slug    string `json:"slug"`
 	Id      int64  `json:"id"`
@@ -22,6 +23,7 @@ type DashboardSaveResponse struct {
 	Version int64  `json:"version"`
 }
 
+// DashboardSearchResponse represents the Grafana API dashboard search response.
 type DashboardSearchResponse struct {
 	Id          uint     `json:"id"`
 	Uid         string   `json:"uid"`
@@ -38,6 +40,7 @@ type DashboardSearchResponse struct {
 	FolderUrl   string   `json:"folderUrl"`
 }
 
+// Dashboard represents a Grafana dashboard.
 type Dashboard struct {
 	Meta      DashboardMeta          `json:"meta"`
 	Model     map[string]interface{} `json:"dashboard"`

--- a/dashboard.go
+++ b/dashboard.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -57,18 +56,13 @@ func (c *Client) SaveDashboard(model map[string]interface{}, overwrite bool) (*D
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.request("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data))
-	if err != nil {
-		return nil, err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	result := &DashboardSaveResponse{}
-	err = json.Unmarshal(data, &result)
+	err = c.request("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, err
 }
 
@@ -78,18 +72,13 @@ func (c *Client) NewDashboard(dashboard Dashboard) (*DashboardSaveResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.request("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data))
-	if err != nil {
-		return nil, err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
 
 	result := &DashboardSaveResponse{}
-	err = json.Unmarshal(data, &result)
+	err = c.request("POST", "/api/dashboards/db", nil, bytes.NewBuffer(data), &result)
+	if err != nil {
+		return nil, err
+	}
+
 	return result, err
 }
 
@@ -99,17 +88,12 @@ func (c *Client) Dashboards() ([]DashboardSearchResponse, error) {
 	query := url.Values{}
 	// search only dashboards
 	query.Add("type", "dash-db")
-	resp, err := c.request("GET", "/api/search", query, nil)
+
+	err := c.request("GET", "/api/search", query, nil, &dashboards)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return dashboards, err
-	}
-
-	err = json.Unmarshal(data, &dashboards)
 	return dashboards, err
 }
 
@@ -131,19 +115,11 @@ func (c *Client) DashboardByUID(uid string) (*Dashboard, error) {
 }
 
 func (c *Client) dashboard(path string) (*Dashboard, error) {
-	resp, err := c.request("GET", path, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	result := &Dashboard{}
-	err = json.Unmarshal(data, &result)
-	result.Folder = result.Meta.Folder
+	err := c.request("GET", path, nil, nil, &result)
+	if err != nil {
+		return nil, err
+	}
 
 	return result, err
 }
@@ -166,7 +142,5 @@ func (c *Client) DeleteDashboardByUID(uid string) error {
 }
 
 func (c *Client) deleteDashboard(path string) error {
-	_, err := c.request("DELETE", path, nil, nil)
-
-	return err
+	return c.request("DELETE", path, nil, nil, nil)
 }

--- a/datasource.go
+++ b/datasource.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -103,22 +102,15 @@ type SecureJSONData struct {
 	PrivateKey string `json:"privateKey,omitempty"`
 }
 
+// NewDataSource creates a new Grafana data source.
 func (c *Client) NewDataSource(s *DataSource) (int64, error) {
 	data, err := json.Marshal(s)
 	if err != nil {
 		return 0, err
 	}
-	req, err := c.newRequest("POST", "/api/datasources", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/datasources", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, err
-	}
-	if resp.StatusCode != 200 {
-		return 0, errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -133,41 +125,24 @@ func (c *Client) NewDataSource(s *DataSource) (int64, error) {
 	return result.Id, err
 }
 
+// UpdateDataSource updates a Grafana data source.
 func (c *Client) UpdateDataSource(s *DataSource) error {
 	path := fmt.Sprintf("/api/datasources/%d", s.Id)
 	data, err := json.Marshal(s)
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
+	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
-
-	return nil
+	return err
 }
 
+// DataSource fetches and returns the Grafana data source whose ID it's passed.
 func (c *Client) DataSource(id int64) (*DataSource, error) {
 	path := fmt.Sprintf("/api/datasources/%d", id)
-	req, err := c.newRequest("GET", path, nil, nil)
+	resp, err := c.request("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -180,20 +155,10 @@ func (c *Client) DataSource(id int64) (*DataSource, error) {
 	return result, err
 }
 
+// DeleteDataSource deletes the Grafana data source whose ID it's passed.
 func (c *Client) DeleteDataSource(id int64) error {
 	path := fmt.Sprintf("/api/datasources/%d", id)
-	req, err := c.newRequest("DELETE", path, nil, nil)
-	if err != nil {
-		return err
-	}
+	_, err := c.request("DELETE", path, nil, nil)
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
-
-	return nil
+	return err
 }

--- a/datasource.go
+++ b/datasource.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// DataSource represents a Grafana data source.
 type DataSource struct {
 	Id     int64  `json:"id,omitempty"`
 	Name   string `json:"name"`

--- a/folder.go
+++ b/folder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// Folder represents a Grafana folder.
 type Folder struct {
 	Id    int64  `json:"id"`
 	Uid   string `json:"uid"`

--- a/folder.go
+++ b/folder.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -14,20 +13,14 @@ type Folder struct {
 	Title string `json:"title"`
 }
 
+// Folders fetches and returns Grafana folders.
 func (c *Client) Folders() ([]Folder, error) {
 	folders := make([]Folder, 0)
+	resp, err := c.request("GET", "/api/folders/", nil, nil)
+	if err != nil {
+		return folders, err
+	}
 
-	req, err := c.newRequest("GET", "/api/folders/", nil, nil)
-	if err != nil {
-		return folders, err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return folders, err
-	}
-	if resp.StatusCode != 200 {
-		return folders, errors.New(resp.Status)
-	}
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return folders, err
@@ -36,19 +29,14 @@ func (c *Client) Folders() ([]Folder, error) {
 	return folders, err
 }
 
+// Folder fetches and returns the Grafana folder whose ID it's passed.
 func (c *Client) Folder(id int64) (*Folder, error) {
 	folder := &Folder{}
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/folders/id/%d", id), nil, nil)
+	resp, err := c.request("GET", fmt.Sprintf("/api/folders/id/%d", id), nil, nil)
 	if err != nil {
 		return folder, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return folder, err
-	}
-	if resp.StatusCode != 200 {
-		return folder, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return folder, err
@@ -57,6 +45,7 @@ func (c *Client) Folder(id int64) (*Folder, error) {
 	return folder, err
 }
 
+// NewFolder creates a new Grafana folder.
 func (c *Client) NewFolder(title string) (Folder, error) {
 	folder := Folder{}
 	dataMap := map[string]string{
@@ -66,18 +55,11 @@ func (c *Client) NewFolder(title string) (Folder, error) {
 	if err != nil {
 		return folder, err
 	}
-	req, err := c.newRequest("POST", "/api/folders", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/folders", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return folder, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return folder, err
-	}
-	if resp.StatusCode != 200 {
-		data, _ = ioutil.ReadAll(resp.Body)
-		return folder, fmt.Errorf("status: %s body: %s", resp.Status, data)
-	}
+
 	data, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return folder, err
@@ -89,6 +71,7 @@ func (c *Client) NewFolder(title string) (Folder, error) {
 	return folder, err
 }
 
+// UpdateFolder updates the folder whose ID it's passed.
 func (c *Client) UpdateFolder(id string, name string) error {
 	dataMap := map[string]string{
 		"name": name,
@@ -97,31 +80,14 @@ func (c *Client) UpdateFolder(id string, name string) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", fmt.Sprintf("/api/folders/%s", id), nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err = c.request("PUT", fmt.Sprintf("/api/folders/%s", id), nil, bytes.NewBuffer(data))
+
 	return err
 }
 
+// DeleteFolder deletes the folder whose ID it's passed.
 func (c *Client) DeleteFolder(id string) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/folders/%s", id), nil, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err := c.request("DELETE", fmt.Sprintf("/api/folders/%s", id), nil, nil)
+
 	return err
 }

--- a/folder.go
+++ b/folder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 type Folder struct {
@@ -16,32 +15,22 @@ type Folder struct {
 // Folders fetches and returns Grafana folders.
 func (c *Client) Folders() ([]Folder, error) {
 	folders := make([]Folder, 0)
-	resp, err := c.request("GET", "/api/folders/", nil, nil)
+	err := c.request("GET", "/api/folders/", nil, nil, &folders)
 	if err != nil {
 		return folders, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return folders, err
-	}
-	err = json.Unmarshal(data, &folders)
 	return folders, err
 }
 
 // Folder fetches and returns the Grafana folder whose ID it's passed.
 func (c *Client) Folder(id int64) (*Folder, error) {
 	folder := &Folder{}
-	resp, err := c.request("GET", fmt.Sprintf("/api/folders/id/%d", id), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/folders/id/%d", id), nil, nil, folder)
 	if err != nil {
 		return folder, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return folder, err
-	}
-	err = json.Unmarshal(data, &folder)
 	return folder, err
 }
 
@@ -55,19 +44,12 @@ func (c *Client) NewFolder(title string) (Folder, error) {
 	if err != nil {
 		return folder, err
 	}
-	resp, err := c.request("POST", "/api/folders", nil, bytes.NewBuffer(data))
+
+	err = c.request("POST", "/api/folders", nil, bytes.NewBuffer(data), &folder)
 	if err != nil {
 		return folder, err
 	}
 
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return folder, err
-	}
-	err = json.Unmarshal(data, &folder)
-	if err != nil {
-		return folder, err
-	}
 	return folder, err
 }
 
@@ -80,14 +62,11 @@ func (c *Client) UpdateFolder(id string, name string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.request("PUT", fmt.Sprintf("/api/folders/%s", id), nil, bytes.NewBuffer(data))
 
-	return err
+	return c.request("PUT", fmt.Sprintf("/api/folders/%s", id), nil, bytes.NewBuffer(data), nil)
 }
 
 // DeleteFolder deletes the folder whose ID it's passed.
 func (c *Client) DeleteFolder(id string) error {
-	_, err := c.request("DELETE", fmt.Sprintf("/api/folders/%s", id), nil, nil)
-
-	return err
+	return c.request("DELETE", fmt.Sprintf("/api/folders/%s", id), nil, nil, nil)
 }

--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -41,20 +41,14 @@ type PermissionItem struct {
 	Permission int64  `json:"permission"`
 }
 
+// FolderPermissions fetches and returns the permissions for the folder whose ID it's passed.
 func (c *Client) FolderPermissions(fid string) ([]*FolderPermission, error) {
 	permissions := make([]*FolderPermission, 0)
+	resp, err := c.request("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil)
+	if err != nil {
+		return permissions, err
+	}
 
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil)
-	if err != nil {
-		return permissions, err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return permissions, err
-	}
-	if resp.StatusCode != 200 {
-		return permissions, fmt.Errorf(resp.Status)
-	}
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return permissions, err
@@ -72,17 +66,8 @@ func (c *Client) UpdateFolderPermissions(fid string, items *PermissionItems) err
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("POST", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf(resp.Status)
-	}
-	return nil
+	_, err = c.request("POST", path, nil, bytes.NewBuffer(data))
+
+	return err
 }

--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 // FolderPermission has information such as a folder, user, team, role and permission.
@@ -44,18 +43,11 @@ type PermissionItem struct {
 // FolderPermissions fetches and returns the permissions for the folder whose ID it's passed.
 func (c *Client) FolderPermissions(fid string) ([]*FolderPermission, error) {
 	permissions := make([]*FolderPermission, 0)
-	resp, err := c.request("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/folders/%s/permissions", fid), nil, nil, &permissions)
 	if err != nil {
 		return permissions, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return permissions, err
-	}
-	if err := json.Unmarshal(data, &permissions); err != nil {
-		return permissions, err
-	}
 	return permissions, nil
 }
 
@@ -67,7 +59,5 @@ func (c *Client) UpdateFolderPermissions(fid string, items *PermissionItems) err
 		return err
 	}
 
-	_, err = c.request("POST", path, nil, bytes.NewBuffer(data))
-
-	return err
+	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
 }

--- a/folder_permissions.go
+++ b/folder_permissions.go
@@ -27,10 +27,12 @@ type FolderPermission struct {
 	DashboardId int64 `json:"dashboardId,omitempty"`
 }
 
+// PermissionItems represents Grafana folder permission items.
 type PermissionItems struct {
 	Items []*PermissionItem `json:"items"`
 }
 
+// PermissionItem represents a Grafana folder permission item.
 type PermissionItem struct {
 	// As you can see the docs, each item has a pair of [Role|TeamId|UserId] and Permission.
 	// unnecessary fields are omitted.

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,3 @@ require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b
 	github.com/hashicorp/go-cleanhttp v0.5.1
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b
 	github.com/hashicorp/go-cleanhttp v0.5.1
 )
+
+go 1.13

--- a/org_users.go
+++ b/org_users.go
@@ -16,9 +16,9 @@ type OrgUser struct {
 }
 
 // OrgUsers fetches and returns the users for the org whose ID it's passed.
-func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
+func (c *Client) OrgUsers(orgID int64) ([]OrgUser, error) {
 	users := make([]OrgUser, 0)
-	err := c.request("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil, &users)
+	err := c.request("GET", fmt.Sprintf("/api/orgs/%d/users", orgID), nil, nil, &users)
 	if err != nil {
 		return users, err
 	}
@@ -27,7 +27,7 @@ func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
 }
 
 // AddOrgUser adds a user to an org with the specified role.
-func (c *Client) AddOrgUser(orgId int64, user, role string) error {
+func (c *Client) AddOrgUser(orgID int64, user, role string) error {
 	dataMap := map[string]string{
 		"loginOrEmail": user,
 		"role":         role,
@@ -37,11 +37,11 @@ func (c *Client) AddOrgUser(orgId int64, user, role string) error {
 		return err
 	}
 
-	return c.request("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data), nil)
+	return c.request("POST", fmt.Sprintf("/api/orgs/%d/users", orgID), nil, bytes.NewBuffer(data), nil)
 }
 
 // UpdateOrgUser updates and org user.
-func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
+func (c *Client) UpdateOrgUser(orgID, userID int64, role string) error {
 	dataMap := map[string]string{
 		"role": role,
 	}
@@ -50,10 +50,10 @@ func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
 		return err
 	}
 
-	return c.request("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data), nil)
+	return c.request("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgID, userID), nil, bytes.NewBuffer(data), nil)
 }
 
 // RemoveOrgUser removes a user from an org.
-func (c *Client) RemoveOrgUser(orgId, userId int64) error {
-	return c.request("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil, nil)
+func (c *Client) RemoveOrgUser(orgID, userID int64) error {
+	return c.request("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgID, userID), nil, nil, nil)
 }

--- a/org_users.go
+++ b/org_users.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// OrgUser represents a Grafana org user.
 type OrgUser struct {
 	OrgId  int64  `json:"orgId"`
 	UserId int64  `json:"userId"`

--- a/org_users.go
+++ b/org_users.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 type OrgUser struct {
@@ -18,19 +17,11 @@ type OrgUser struct {
 // OrgUsers fetches and returns the users for the org whose ID it's passed.
 func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
 	users := make([]OrgUser, 0)
-	resp, err := c.request("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil, &users)
 	if err != nil {
 		return users, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return users, err
-	}
-	err = json.Unmarshal(data, &users)
-	if err != nil {
-		return users, err
-	}
 	return users, err
 }
 
@@ -45,9 +36,7 @@ func (c *Client) AddOrgUser(orgId int64, user, role string) error {
 		return err
 	}
 
-	_, err = c.request("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data))
-
-	return err
+	return c.request("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data), nil)
 }
 
 // UpdateOrgUser updates and org user.
@@ -59,14 +48,11 @@ func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.request("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data))
 
-	return err
+	return c.request("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data), nil)
 }
 
 // RemoveOrgUser removes a user from an org.
 func (c *Client) RemoveOrgUser(orgId, userId int64) error {
-	_, err := c.request("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil)
-
-	return err
+	return c.request("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil, nil)
 }

--- a/org_users.go
+++ b/org_users.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -16,19 +15,14 @@ type OrgUser struct {
 	Role   string `json:"role"`
 }
 
+// OrgUsers fetches and returns the users for the org whose ID it's passed.
 func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
 	users := make([]OrgUser, 0)
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil)
+	resp, err := c.request("GET", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, nil)
 	if err != nil {
 		return users, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return users, err
-	}
-	if resp.StatusCode != 200 {
-		return users, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return users, err
@@ -40,6 +34,7 @@ func (c *Client) OrgUsers(orgId int64) ([]OrgUser, error) {
 	return users, err
 }
 
+// AddOrgUser adds a user to an org with the specified role.
 func (c *Client) AddOrgUser(orgId int64, user, role string) error {
 	dataMap := map[string]string{
 		"loginOrEmail": user,
@@ -49,20 +44,13 @@ func (c *Client) AddOrgUser(orgId int64, user, role string) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+
+	_, err = c.request("POST", fmt.Sprintf("/api/orgs/%d/users", orgId), nil, bytes.NewBuffer(data))
+
 	return err
 }
 
+// UpdateOrgUser updates and org user.
 func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
 	dataMap := map[string]string{
 		"role": role,
@@ -71,31 +59,14 @@ func (c *Client) UpdateOrgUser(orgId, userId int64, role string) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err = c.request("PATCH", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, bytes.NewBuffer(data))
+
 	return err
 }
 
+// RemoveOrgUser removes a user from an org.
 func (c *Client) RemoveOrgUser(orgId, userId int64) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err := c.request("DELETE", fmt.Sprintf("/api/orgs/%d/users/%d", orgId, userId), nil, nil)
+
 	return err
 }

--- a/orgs.go
+++ b/orgs.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -13,20 +12,15 @@ type Org struct {
 	Name string `json:"name"`
 }
 
+// Orgs fetches and returns the Grafana orgs.
 func (c *Client) Orgs() ([]Org, error) {
 	orgs := make([]Org, 0)
 
-	req, err := c.newRequest("GET", "/api/orgs/", nil, nil)
+	resp, err := c.request("GET", "/api/orgs/", nil, nil)
 	if err != nil {
 		return orgs, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return orgs, err
-	}
-	if resp.StatusCode != 200 {
-		return orgs, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return orgs, err
@@ -35,19 +29,14 @@ func (c *Client) Orgs() ([]Org, error) {
 	return orgs, err
 }
 
+// OrgByName fetches and returns the org whose name it's passed.
 func (c *Client) OrgByName(name string) (Org, error) {
 	org := Org{}
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/name/%s", name), nil, nil)
+	resp, err := c.request("GET", fmt.Sprintf("/api/orgs/name/%s", name), nil, nil)
 	if err != nil {
 		return org, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return org, err
-	}
-	if resp.StatusCode != 200 {
-		return org, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return org, err
@@ -56,19 +45,14 @@ func (c *Client) OrgByName(name string) (Org, error) {
 	return org, err
 }
 
+// Org fetches and returns the org whose ID it's passed.
 func (c *Client) Org(id int64) (Org, error) {
 	org := Org{}
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
+	resp, err := c.request("GET", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
 	if err != nil {
 		return org, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return org, err
-	}
-	if resp.StatusCode != 200 {
-		return org, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return org, err
@@ -77,6 +61,7 @@ func (c *Client) Org(id int64) (Org, error) {
 	return org, err
 }
 
+// NewOrg creates a new Grafana org.
 func (c *Client) NewOrg(name string) (int64, error) {
 	id := int64(0)
 
@@ -87,17 +72,11 @@ func (c *Client) NewOrg(name string) (int64, error) {
 	if err != nil {
 		return id, err
 	}
-	req, err := c.newRequest("POST", "/api/orgs", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/orgs", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return id, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return id, err
-	}
-	if resp.StatusCode != 200 {
-		return id, errors.New(resp.Status)
-	}
+
 	data, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return id, err
@@ -113,6 +92,7 @@ func (c *Client) NewOrg(name string) (int64, error) {
 	return id, err
 }
 
+// UpdateOrg updates a Grafana org.
 func (c *Client) UpdateOrg(id int64, name string) error {
 	dataMap := map[string]string{
 		"name": name,
@@ -121,31 +101,14 @@ func (c *Client) UpdateOrg(id int64, name string) error {
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest("PUT", fmt.Sprintf("/api/orgs/%d", id), nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err = c.request("PUT", fmt.Sprintf("/api/orgs/%d", id), nil, bytes.NewBuffer(data))
+
 	return err
 }
 
+// DeleteOrg deletes the Grafana org whose ID it's passed.
 func (c *Client) DeleteOrg(id int64) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
+	_, err := c.request("DELETE", fmt.Sprintf("/api/orgs/%d", id), nil, nil)
+
 	return err
 }

--- a/orgs.go
+++ b/orgs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// Org represents a Grafana org.
 type Org struct {
 	Id   int64  `json:"id"`
 	Name string `json:"name"`

--- a/playlist.go
+++ b/playlist.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 type PlaylistItem struct {
@@ -24,19 +23,8 @@ type Playlist struct {
 // Playlist fetches and returns a Grafana playlist.
 func (c *Client) Playlist(id int) (*Playlist, error) {
 	path := fmt.Sprintf("/api/playlists/%d", id)
-	resp, err := c.request("GET", path, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	playlist := &Playlist{}
-
-	err = json.Unmarshal(data, &playlist)
+	err := c.request("GET", path, nil, nil, playlist)
 	if err != nil {
 		return nil, err
 	}
@@ -51,21 +39,11 @@ func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
 		return 0, err
 	}
 
-	resp, err := c.request("POST", "/api/playlists", nil, bytes.NewBuffer(data))
-	if err != nil {
-		return 0, err
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
-
 	result := struct {
 		Id int
 	}{}
 
-	err = json.Unmarshal(data, &result)
+	err = c.request("POST", "/api/playlists", nil, bytes.NewBuffer(data), &result)
 	if err != nil {
 		return 0, err
 	}
@@ -81,15 +59,12 @@ func (c *Client) UpdatePlaylist(playlist Playlist) error {
 		return err
 	}
 
-	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
-
-	return err
+	return c.request("PUT", path, nil, bytes.NewBuffer(data), nil)
 }
 
 // DeletePlaylist deletes the Grafana playlist whose ID it's passed.
 func (c *Client) DeletePlaylist(id int) error {
 	path := fmt.Sprintf("/api/playlists/%d", id)
-	_, err := c.request("DELETE", path, nil, nil)
 
-	return err
+	return c.request("DELETE", path, nil, nil, nil)
 }

--- a/playlist.go
+++ b/playlist.go
@@ -14,7 +14,7 @@ type PlaylistItem struct {
 	Title string `json:"title"`
 }
 
-// PlaylistItem represents a Grafana playlist.
+// Playlist represents a Grafana playlist.
 type Playlist struct {
 	Id       int            `json:"id"`
 	Name     string         `json:"name"`

--- a/playlist.go
+++ b/playlist.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 )
 
+// PlaylistItem represents a Grafana playlist item.
 type PlaylistItem struct {
 	Type  string `json:"type"`
 	Value string `json:"value"`
@@ -13,6 +14,7 @@ type PlaylistItem struct {
 	Title string `json:"title"`
 }
 
+// PlaylistItem represents a Grafana playlist.
 type Playlist struct {
 	Id       int            `json:"id"`
 	Name     string         `json:"name"`

--- a/playlist.go
+++ b/playlist.go
@@ -3,7 +3,6 @@ package gapi
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 )
@@ -22,20 +21,12 @@ type Playlist struct {
 	Items    []PlaylistItem `json:"items"`
 }
 
+// Playlist fetches and returns a Grafana playlist.
 func (c *Client) Playlist(id int) (*Playlist, error) {
 	path := fmt.Sprintf("/api/playlists/%d", id)
-	req, err := c.newRequest("GET", path, nil, nil)
+	resp, err := c.request("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, errors.New(resp.Status)
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
@@ -53,24 +44,16 @@ func (c *Client) Playlist(id int) (*Playlist, error) {
 	return playlist, nil
 }
 
+// NewPlaylist creates a new Grafana playlist.
 func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
 	data, err := json.Marshal(playlist)
 	if err != nil {
 		return 0, err
 	}
 
-	req, err := c.newRequest("POST", "/api/playlists", nil, bytes.NewBuffer(data))
+	resp, err := c.request("POST", "/api/playlists", nil, bytes.NewBuffer(data))
 	if err != nil {
 		return 0, err
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return 0, err
-	}
-
-	if resp.StatusCode != 200 {
-		return 0, errors.New(resp.Status)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -90,6 +73,7 @@ func (c *Client) NewPlaylist(playlist Playlist) (int, error) {
 	return result.Id, nil
 }
 
+// UpdatePlaylist updates a Grafana playlist.
 func (c *Client) UpdatePlaylist(playlist Playlist) error {
 	path := fmt.Sprintf("/api/playlists/%d", playlist.Id)
 	data, err := json.Marshal(playlist)
@@ -97,38 +81,15 @@ func (c *Client) UpdatePlaylist(playlist Playlist) error {
 		return err
 	}
 
-	req, err := c.newRequest("PUT", path, nil, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
+	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
-
-	return nil
+	return err
 }
 
+// DeletePlaylist deletes the Grafana playlist whose ID it's passed.
 func (c *Client) DeletePlaylist(id int) error {
 	path := fmt.Sprintf("/api/playlists/%d", id)
-	req, err := c.newRequest("DELETE", path, nil, nil)
-	if err != nil {
-		return err
-	}
+	_, err := c.request("DELETE", path, nil, nil)
 
-	resp, err := c.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != 200 {
-		return errors.New(resp.Status)
-	}
-
-	return nil
+	return err
 }

--- a/team.go
+++ b/team.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 )
 
+// SearchTeam represents a search for a Grafana team.
 type SearchTeam struct {
 	TotalCount int64   `json:"totalCount,omitempty"`
 	Teams      []*Team `json:"teams,omitempty"`
@@ -26,7 +27,7 @@ type Team struct {
 	Permission  int64  `json:"permission,omitempty"`
 }
 
-// TeamMember
+// TeamMember represents a Grafana team member.
 type TeamMember struct {
 	OrgId      int64  `json:"orgId,omitempty"`
 	TeamId     int64  `json:"teamId,omitempty"`
@@ -37,6 +38,7 @@ type TeamMember struct {
 	Permission int64  `json:"permission,omitempty"`
 }
 
+// Preferences represents Grafana preferences.
 type Preferences struct {
 	Theme           string `json:"theme"`
 	HomeDashboardId int64  `json:"homeDashboardId"`

--- a/team.go
+++ b/team.go
@@ -68,7 +68,6 @@ func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
 // Team fetches and returns the Grafana team whose ID it's passed.
 func (c *Client) Team(id int64) (*Team, error) {
 	team := &Team{}
-
 	err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil, team)
 	if err != nil {
 		return nil, err
@@ -120,7 +119,6 @@ func (c *Client) DeleteTeam(id int64) error {
 // TeamMembers fetches and returns the team members for the Grafana team whose ID it's passed.
 func (c *Client) TeamMembers(id int64) ([]*TeamMember, error) {
 	members := make([]*TeamMember, 0)
-
 	err := c.request("GET", fmt.Sprintf("/api/teams/%d/members", id), nil, nil, &members)
 	if err != nil {
 		return members, err
@@ -130,9 +128,9 @@ func (c *Client) TeamMembers(id int64) ([]*TeamMember, error) {
 }
 
 // AddTeamMember adds a user to the Grafana team whose ID it's passed.
-func (c *Client) AddTeamMember(id int64, userId int64) error {
+func (c *Client) AddTeamMember(id int64, userID int64) error {
 	path := fmt.Sprintf("/api/teams/%d/members", id)
-	member := TeamMember{UserId: userId}
+	member := TeamMember{UserId: userID}
 	data, err := json.Marshal(member)
 	if err != nil {
 		return err
@@ -142,8 +140,8 @@ func (c *Client) AddTeamMember(id int64, userId int64) error {
 }
 
 // RemoveMemberFromTeam removes a user from the Grafana team whose ID it's passed.
-func (c *Client) RemoveMemberFromTeam(id int64, userId int64) error {
-	path := fmt.Sprintf("/api/teams/%d/members/%d", id, userId)
+func (c *Client) RemoveMemberFromTeam(id int64, userID int64) error {
+	path := fmt.Sprintf("/api/teams/%d/members/%d", id, userID)
 
 	return c.request("DELETE", path, nil, nil, nil)
 }
@@ -151,7 +149,6 @@ func (c *Client) RemoveMemberFromTeam(id int64, userId int64) error {
 // TeamPreferences fetches and returns preferences for the Grafana team whose ID it's passed.
 func (c *Client) TeamPreferences(id int64) (*Preferences, error) {
 	preferences := &Preferences{}
-
 	err := c.request("GET", fmt.Sprintf("/api/teams/%d/preferences", id), nil, nil, preferences)
 	if err != nil {
 		return nil, err
@@ -161,11 +158,11 @@ func (c *Client) TeamPreferences(id int64) (*Preferences, error) {
 }
 
 // UpdateTeamPreferences updates team preferences for the Grafana team whose ID it's passed.
-func (c *Client) UpdateTeamPreferences(id int64, theme string, homeDashboardId int64, timezone string) error {
+func (c *Client) UpdateTeamPreferences(id int64, theme string, homeDashboardID int64, timezone string) error {
 	path := fmt.Sprintf("/api/teams/%d", id)
 	preferences := Preferences{
 		Theme:           theme,
-		HomeDashboardId: homeDashboardId,
+		HomeDashboardId: homeDashboardID,
 		Timezone:        timezone,
 	}
 	data, err := json.Marshal(preferences)

--- a/team.go
+++ b/team.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -56,38 +55,24 @@ func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
 	queryValues.Set("perPage", perPage)
 	queryValues.Set("query", query)
 
-	resp, err := c.request("GET", path, queryValues, nil)
+	err := c.request("GET", path, queryValues, nil, &result)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, err
-	}
 	return &result, nil
 }
 
 // Team fetches and returns the Grafana team whose ID it's passed.
 func (c *Client) Team(id int64) (*Team, error) {
-	var team Team
+	team := &Team{}
 
-	resp, err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil, team)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(data, &team); err != nil {
-		return nil, err
-	}
-	return &team, nil
+	return team, nil
 }
 
 // AddTeam makes a new team
@@ -104,9 +89,7 @@ func (c *Client) AddTeam(name string, email string) error {
 		return err
 	}
 
-	_, err = c.request("POST", path, nil, bytes.NewBuffer(data))
-
-	return err
+	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
 }
 
 // UpdateTeam updates a Grafana team.
@@ -124,34 +107,23 @@ func (c *Client) UpdateTeam(id int64, name string, email string) error {
 		return err
 	}
 
-	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
-
-	return err
+	return c.request("PUT", path, nil, bytes.NewBuffer(data), nil)
 }
 
 // DeleteTeam deletes the Grafana team whose ID it's passed.
 func (c *Client) DeleteTeam(id int64) error {
-	_, err := c.request("DELETE", fmt.Sprintf("/api/teams/%d", id), nil, nil)
-
-	return err
+	return c.request("DELETE", fmt.Sprintf("/api/teams/%d", id), nil, nil, nil)
 }
 
 // TeamMembers fetches and returns the team members for the Grafana team whose ID it's passed.
 func (c *Client) TeamMembers(id int64) ([]*TeamMember, error) {
 	members := make([]*TeamMember, 0)
 
-	resp, err := c.request("GET", fmt.Sprintf("/api/teams/%d/members", id), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/teams/%d/members", id), nil, nil, &members)
 	if err != nil {
 		return members, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return members, err
-	}
-	if err := json.Unmarshal(data, &members); err != nil {
-		return members, err
-	}
 	return members, nil
 }
 
@@ -163,37 +135,27 @@ func (c *Client) AddTeamMember(id int64, userId int64) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.request("POST", path, nil, bytes.NewBuffer(data))
 
-	return err
+	return c.request("POST", path, nil, bytes.NewBuffer(data), nil)
 }
 
 // RemoveMemberFromTeam removes a user from the Grafana team whose ID it's passed.
 func (c *Client) RemoveMemberFromTeam(id int64, userId int64) error {
 	path := fmt.Sprintf("/api/teams/%d/members/%d", id, userId)
-	_, err := c.request("DELETE", path, nil, nil)
 
-	return err
+	return c.request("DELETE", path, nil, nil, nil)
 }
 
 // TeamPreferences fetches and returns preferences for the Grafana team whose ID it's passed.
 func (c *Client) TeamPreferences(id int64) (*Preferences, error) {
-	var preferences Preferences
+	preferences := &Preferences{}
 
-	resp, err := c.request("GET", fmt.Sprintf("/api/teams/%d/preferences", id), nil, nil)
+	err := c.request("GET", fmt.Sprintf("/api/teams/%d/preferences", id), nil, nil, preferences)
 	if err != nil {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(data, &preferences); err != nil {
-		return nil, err
-	}
-
-	return &preferences, nil
+	return preferences, nil
 }
 
 // UpdateTeamPreferences updates team preferences for the Grafana team whose ID it's passed.
@@ -208,7 +170,6 @@ func (c *Client) UpdateTeamPreferences(id int64, theme string, homeDashboardId i
 	if err != nil {
 		return err
 	}
-	_, err = c.request("PUT", path, nil, bytes.NewBuffer(data))
 
-	return err
+	return c.request("PUT", path, nil, bytes.NewBuffer(data), nil)
 }

--- a/user.go
+++ b/user.go
@@ -2,7 +2,6 @@ package gapi
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"net/url"
 )
@@ -16,19 +15,14 @@ type User struct {
 	IsAdmin  bool   `json:"isAdmin,omitempty"`
 }
 
+// Users fetches and returns Grafana users.
 func (c *Client) Users() ([]User, error) {
 	users := make([]User, 0)
-	req, err := c.newRequest("GET", "/api/users", nil, nil)
+	resp, err := c.request("GET", "/api/users", nil, nil)
 	if err != nil {
 		return users, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return users, err
-	}
-	if resp.StatusCode != 200 {
-		return users, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return users, err
@@ -40,21 +34,16 @@ func (c *Client) Users() ([]User, error) {
 	return users, err
 }
 
+// UserByEmail fetches and returns the user whose email matches that passed.
 func (c *Client) UserByEmail(email string) (User, error) {
 	user := User{}
 	query := url.Values{}
 	query.Add("loginOrEmail", email)
-	req, err := c.newRequest("GET", "/api/users/lookup", query, nil)
+	resp, err := c.request("GET", "/api/users/lookup", query, nil)
 	if err != nil {
 		return user, err
 	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return user, err
-	}
-	if resp.StatusCode != 200 {
-		return user, errors.New(resp.Status)
-	}
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return user, err

--- a/user.go
+++ b/user.go
@@ -1,8 +1,6 @@
 package gapi
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"net/url"
 )
 
@@ -18,19 +16,11 @@ type User struct {
 // Users fetches and returns Grafana users.
 func (c *Client) Users() ([]User, error) {
 	users := make([]User, 0)
-	resp, err := c.request("GET", "/api/users", nil, nil)
+	err := c.request("GET", "/api/users", nil, nil, &users)
 	if err != nil {
 		return users, err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return users, err
-	}
-	err = json.Unmarshal(data, &users)
-	if err != nil {
-		return users, err
-	}
 	return users, err
 }
 
@@ -39,15 +29,6 @@ func (c *Client) UserByEmail(email string) (User, error) {
 	user := User{}
 	query := url.Values{}
 	query.Add("loginOrEmail", email)
-	resp, err := c.request("GET", "/api/users/lookup", query, nil)
-	if err != nil {
-		return user, err
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return user, err
-	}
 	tmp := struct {
 		Id       int64  `json:"id,omitempty"`
 		Email    string `json:"email,omitempty"`
@@ -56,10 +37,13 @@ func (c *Client) UserByEmail(email string) (User, error) {
 		Password string `json:"password,omitempty"`
 		IsAdmin  bool   `json:"isGrafanaAdmin,omitempty"`
 	}{}
-	err = json.Unmarshal(data, &tmp)
+
+	err := c.request("GET", "/api/users/lookup", query, nil, &tmp)
 	if err != nil {
 		return user, err
 	}
+
 	user = User(tmp)
+
 	return user, err
 }

--- a/user.go
+++ b/user.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 )
 
+// User represents a Grafana user.
 type User struct {
 	Id       int64  `json:"id,omitempty"`
 	Email    string `json:"email,omitempty"`


### PR DESCRIPTION
While this refactor unfortunately touches a lot of files, I'd argue it's a relatively simple refactor with some substantive benefits:

* resolves #49 
* resolves #50 
* resolves #52 
* resolves #53 
* resolves #17
* removes many lines of repetitive code by 1) centralizing HTTP request handling 2) centralizing JSON unmarshaling 
* improves test coverage by > 10 % without touching any existing `_test.go` files (`master` has `coverage: 65.7% of statements` while this branch has `coverage: 76.9% of statements`)
* cleans up a few function parameter names to use capitalized acronyms, as per [Go convention](https://github.com/golang/go/wiki/CodeReviewComments#initialisms) (this has the added benefit of quieting editor complaints for those developers whose editors enforce Golang best practices)
* adds tests of `client` `New`, which previously did not exist (note that these tests are _not_ what's responsible for raising the test coverage, though. The refactor alone is responsible for raising the test coverage)