### PR TITLE
Integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,22 @@ Grafana HTTP API Client for Go
 
 ## Tests
 
-To run the tests:
+To run unit tests:
 
 ```
-go test
+make test
+```
+
+To run integration tests:
+
+Start a `localhost:3000` Grafana:
+
+```
+make serve-grafana
+```
+
+Run the integration tests:
+
+```
+make integration-test:
 ```

--- a/annotation_integration_test.go
+++ b/annotation_integration_test.go
@@ -1,0 +1,85 @@
+// +build integration
+
+package gapi
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+func TestAnnotationsIntegration(t *testing.T) {
+	client, err := New("admin:admin", "http://localhost:3000")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = client.Annotations(url.Values{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNewAnnotationIntegration(t *testing.T) {
+	client, err := New("admin:admin", "http://localhost:3000")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = client.NewAnnotation(&Annotation{
+		Text: "integration-test-new",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateAnnotationIntegration(t *testing.T) {
+	client, err := New("admin:admin", "http://localhost:3000")
+	if err != nil {
+		t.Error(err)
+	}
+
+	id, err := client.NewAnnotation(&Annotation{
+		Text: "integration-test-update",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	message, err := client.UpdateAnnotation(id, &Annotation{
+		Text: "integration-test-updated",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := "Annotation updated"
+	if message != expected {
+		t.Error(fmt.Sprintf("expected UpdateAnnotation message to be %s; got %s", expected, message))
+	}
+}
+
+func TestDeleteAnnotationIntegration(t *testing.T) {
+	client, err := New("admin:admin", "http://localhost:3000")
+	if err != nil {
+		t.Error(err)
+	}
+
+	id, err := client.NewAnnotation(&Annotation{
+		Text: "integration-test-delete",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	message, err := client.DeleteAnnotation(id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := "Annotation deleted"
+	if message != expected {
+		t.Error(fmt.Sprintf("expected DeleteAnnotation message to be %s; got %s", expected, message))
+	}
+}


### PR DESCRIPTION
This seeks to address issue #58, and to also provide an example set of `annotations_integration_test.go` tests.

It also illustrates the problem outlined in issue #56, as `TestAnnotationsIntegration` will fail until PR #57 is merged:

```sh
$ make integration-test
go test -tags=integration
--- FAIL: TestAnnotationsIntegration (0.03s)
    annotation_integration_test.go:19: invalid character '<' looking for beginning of value
FAIL
exit status 1
FAIL    github.com/nytm/go-grafana-api  0.244s
make: *** [integration-test] Error 1
```