### PR TITLE
Add Postgres SSL Fields to JSONData

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -66,6 +66,9 @@ type JSONData struct {
 
 	// Used by PostgreSQL
 	Sslmode         string `json:"sslmode,omitempty"`
+	SslRootCertFile string `json:"sslRootCertFile,omitempty"`
+	SslCertFile     string `json:"sslCertFile,omitempty"`
+	SslKeyFile      string `json:"sslKeyFile,omitempty"`
 	PostgresVersion int64  `json:"postgresVersion,omitempty"`
 	Timescaledb     bool   `json:"timescaledb,omitempty"`
 


### PR DESCRIPTION
Closes https://github.com/nytm/go-grafana-api/issues/43.

These fields are necessary when `sslMode` is set to ‘require’, ‘verify-ca’ or ‘verify-full’.