### PR TITLE
Refactor User Type, Add Additional User Endpoints

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -48,6 +48,16 @@ func (c *Client) UpdateUserPassword(id int64, password string) error {
 	return c.request("PUT", fmt.Sprintf("/api/admin/users/%d/password", id), nil, bytes.NewBuffer(data), nil)
 }
 
+// UpdateUserPermissions sets a user's admin status.
+func (c *Client) UpdateUserPermissions(id int64, isAdmin bool) error {
+	body := map[string]bool{"isGrafanaAdmin": isAdmin}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	return c.request("PUT", fmt.Sprintf("/api/admin/users/%d/permissions", id), nil, bytes.NewBuffer(data), nil)
+}
+
 // PauseAllAlerts pauses all Grafana alerts.
 func (c *Client) PauseAllAlerts() (PauseAllAlertsResponse, error) {
 	result := PauseAllAlertsResponse{}

--- a/admin.go
+++ b/admin.go
@@ -38,6 +38,16 @@ func (c *Client) DeleteUser(id int64) error {
 	return c.request("DELETE", fmt.Sprintf("/api/admin/users/%d", id), nil, nil, nil)
 }
 
+// UpdateUserPassword updates a user password.
+func (c *Client) UpdateUserPassword(id int64, password string) error {
+	body := map[string]string{"password": password}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	return c.request("PUT", fmt.Sprintf("/api/admin/users/%d/password", id), nil, bytes.NewBuffer(data), nil)
+}
+
 // PauseAllAlerts pauses all Grafana alerts.
 func (c *Client) PauseAllAlerts() (PauseAllAlertsResponse, error) {
 	result := PauseAllAlertsResponse{}

--- a/admin_test.go
+++ b/admin_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	createUserJSON         = `{"id":1,"message":"User created"}`
-	deleteUserJSON         = `{"message":"User deleted"}`
-	updateUserPasswordJSON = `{"message":"User password updated"}`
+	createUserJSON            = `{"id":1,"message":"User created"}`
+	deleteUserJSON            = `{"message":"User deleted"}`
+	updateUserPasswordJSON    = `{"message":"User password updated"}`
+	updateUserPermissionsJSON = `{"message":"User permissions updated"}`
 
 	pauseAllAlertsJSON = `{
 		"alertsAffected": 1,
@@ -53,6 +54,16 @@ func TestUpdateUserPassword(t *testing.T) {
 	defer server.Close()
 
 	err := client.UpdateUserPassword(int64(1), "new-password")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateUserPermissions(t *testing.T) {
+	server, client := gapiTestTools(200, updateUserPermissionsJSON)
+	defer server.Close()
+
+	err := client.UpdateUserPermissions(int64(1), false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/admin_test.go
+++ b/admin_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	createUserJSON = `{"id":1,"message":"User created"}`
-	deleteUserJSON = `{"message":"User deleted"}`
+	createUserJSON         = `{"id":1,"message":"User created"}`
+	deleteUserJSON         = `{"message":"User deleted"}`
+	updateUserPasswordJSON = `{"message":"User password updated"}`
 
 	pauseAllAlertsJSON = `{
 		"alertsAffected": 1,
@@ -42,6 +43,16 @@ func TestDeleteUser(t *testing.T) {
 	defer server.Close()
 
 	err := client.DeleteUser(int64(1))
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateUserPassword(t *testing.T) {
+	server, client := gapiTestTools(200, updateUserPasswordJSON)
+	defer server.Close()
+
+	err := client.UpdateUserPassword(int64(1), "new-password")
 	if err != nil {
 		t.Error(err)
 	}

--- a/user.go
+++ b/user.go
@@ -1,50 +1,63 @@
 package gapi
 
 import (
+	"fmt"
 	"net/url"
+	"time"
 )
 
-// User represents a Grafana user.
+// User represents a Grafana user. It is structured after the UserProfileDTO
+// struct in the Grafana codebase.
 type User struct {
-	Id       int64  `json:"id,omitempty"`
-	Email    string `json:"email,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Login    string `json:"login,omitempty"`
-	Password string `json:"password,omitempty"`
-	IsAdmin  bool   `json:"isAdmin,omitempty"`
+	Id         int64     `json:"id,omitempty"`
+	Email      string    `json:"email,omitempty"`
+	Name       string    `json:"name,omitempty"`
+	Login      string    `json:"login,omitempty"`
+	Theme      string    `json:"theme,omitempty"`
+	OrgId      int64     `json:"orgId,omitempty"`
+	IsAdmin    bool      `json:"isGrafanaAdmin,omitempty"`
+	IsDisabled bool      `json:"isDisabled,omitempty"`
+	IsExternal bool      `json:"isExternal,omitempty"`
+	UpdatedAt  time.Time `json:"updatedAt,omitempty"`
+	CreatedAt  time.Time `json:"createdAt,omitempty"`
+	AuthLabels []string  `json:"authLabels,omitempty"`
+	AvatarUrl  string    `json:"avatarUrl,omitempty"`
+	Password   string    `json:"password,omitempty"`
+}
+
+// UserSearch represents a Grafana user as returned by API endpoints that
+// return a collection of Grafana users. This representation of user has
+// reduced and differing fields. It is structured after the UserSearchHitDTO
+// struct in the Grafana codebase.
+type UserSearch struct {
+	Id            int64     `json:"id,omitempty"`
+	Email         string    `json:"email,omitempty"`
+	Name          string    `json:"name,omitempty"`
+	Login         string    `json:"login,omitempty"`
+	IsAdmin       bool      `json:"isAdmin,omitempty"`
+	IsDisabled    bool      `json:"isDisabled,omitempty"`
+	LastSeenAt    time.Time `json:"lastSeenAt,omitempty"`
+	LastSeenAtAge string    `json:"lastSeenAtAge,omitempty"`
+	AuthLabels    []string  `json:"authLabels,omitempty"`
+	AvatarUrl     string    `json:"avatarUrl,omitempty"`
 }
 
 // Users fetches and returns Grafana users.
-func (c *Client) Users() ([]User, error) {
-	users := make([]User, 0)
-	err := c.request("GET", "/api/users", nil, nil, &users)
-	if err != nil {
-		return users, err
-	}
-
-	return users, err
+func (c *Client) Users() (users []UserSearch, err error) {
+	err = c.request("GET", "/api/users", nil, nil, &users)
+	return
 }
 
-// UserByEmail fetches and returns the user whose email matches that passed.
-func (c *Client) UserByEmail(email string) (User, error) {
-	user := User{}
+// User fetches a user by ID.
+func (c *Client) User(id int64) (user User, err error) {
+	err = c.request("GET", fmt.Sprintf("/api/users/%d", id), nil, nil, &user)
+	return
+}
+
+// UserByEmail fetches a user by email address.
+func (c *Client) UserByEmail(email string) (user User, err error) {
 	query := url.Values{}
 	query.Add("loginOrEmail", email)
-	tmp := struct {
-		Id       int64  `json:"id,omitempty"`
-		Email    string `json:"email,omitempty"`
-		Name     string `json:"name,omitempty"`
-		Login    string `json:"login,omitempty"`
-		Password string `json:"password,omitempty"`
-		IsAdmin  bool   `json:"isGrafanaAdmin,omitempty"`
-	}{}
-
-	err := c.request("GET", "/api/users/lookup", query, nil, &tmp)
-	if err != nil {
-		return user, err
-	}
-
-	user = User(tmp)
-
-	return user, err
+	err = c.request("GET", "/api/users/lookup", query, nil, &user)
+	return
 }

--- a/user.go
+++ b/user.go
@@ -1,6 +1,8 @@
 package gapi
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -60,4 +62,13 @@ func (c *Client) UserByEmail(email string) (user User, err error) {
 	query.Add("loginOrEmail", email)
 	err = c.request("GET", "/api/users/lookup", query, nil, &user)
 	return
+}
+
+// UserUpdate updates a user by ID.
+func (c *Client) UserUpdate(u User) error {
+	data, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+	return c.request("PUT", fmt.Sprintf("/api/users/%d", u.Id), nil, bytes.NewBuffer(data), nil)
 }

--- a/user_test.go
+++ b/user_test.go
@@ -10,6 +10,7 @@ const (
 	getUsersJSON       = `[{"id":1,"email":"users@localhost","isAdmin":true}]`
 	getUserJSON        = `{"id":2,"email":"user@localhost","isGrafanaAdmin":false}`
 	getUserByEmailJSON = `{"id":3,"email":"userByEmail@localhost","isGrafanaAdmin":true}`
+	getUserUpdateJSON  = `{"id":4,"email":"userUpdate@localhost","isGrafanaAdmin":false}`
 )
 
 func TestUsers(t *testing.T) {
@@ -69,5 +70,20 @@ func TestUserByEmail(t *testing.T) {
 		user.Id != 3 ||
 		user.IsAdmin != true {
 		t.Error("Not correctly parsing returned user.")
+	}
+}
+
+func TestUserUpdate(t *testing.T) {
+	server, client := gapiTestTools(200, getUserUpdateJSON)
+	defer server.Close()
+
+	user, err := client.User(4)
+	if err != nil {
+		t.Error(err)
+	}
+	user.IsAdmin = true
+	err = client.UserUpdate(user)
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/user_test.go
+++ b/user_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	getUsersJSON       = `[{"id":1,"name":"","login":"admin","email":"admin@localhost","avatarUrl":"/avatar/46d229b033af06a191ff2267bca9ae56","isAdmin":true,"lastSeenAt":"2018-06-28T14:42:24Z","lastSeenAtAge":"\u003c 1m"}]`
-	getUserByEmailJSON = `{"id":1,"email":"admin@localhost","name":"","login":"admin","theme":"","orgId":1,"isGrafanaAdmin":true}`
+	getUsersJSON       = `[{"id":1,"email":"users@localhost","isAdmin":true}]`
+	getUserJSON        = `{"id":2,"email":"user@localhost","isGrafanaAdmin":false}`
+	getUserByEmailJSON = `{"id":3,"email":"userByEmail@localhost","isGrafanaAdmin":true}`
 )
 
 func TestUsers(t *testing.T) {
@@ -22,16 +23,34 @@ func TestUsers(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	user := User{
-		Id:      1,
-		Email:   "admin@localhost",
-		Name:    "",
-		Login:   "admin",
-		IsAdmin: true,
+	if len(resp) != 1 {
+		t.Fatal("No users were returned.")
 	}
 
-	if len(resp) != 1 || resp[0] != user {
+	user := resp[0]
+
+	if user.Email != "users@localhost" ||
+		user.Id != 1 ||
+		user.IsAdmin != true {
 		t.Error("Not correctly parsing returned users.")
+	}
+}
+
+func TestUser(t *testing.T) {
+	server, client := gapiTestTools(200, getUserJSON)
+	defer server.Close()
+
+	user, err := client.User(1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Log(pretty.PrettyFormat(user))
+
+	if user.Email != "user@localhost" ||
+		user.Id != 2 ||
+		user.IsAdmin != false {
+		t.Error("Not correctly parsing returned user.")
 	}
 }
 
@@ -39,21 +58,16 @@ func TestUserByEmail(t *testing.T) {
 	server, client := gapiTestTools(200, getUserByEmailJSON)
 	defer server.Close()
 
-	resp, err := client.UserByEmail("admin@localhost")
+	user, err := client.UserByEmail("admin@localhost")
 	if err != nil {
 		t.Error(err)
 	}
 
-	t.Log(pretty.PrettyFormat(resp))
+	t.Log(pretty.PrettyFormat(user))
 
-	user := User{
-		Id:      1,
-		Email:   "admin@localhost",
-		Name:    "",
-		Login:   "admin",
-		IsAdmin: true,
-	}
-	if resp != user {
+	if user.Email != "userByEmail@localhost" ||
+		user.Id != 3 ||
+		user.IsAdmin != true {
 		t.Error("Not correctly parsing returned user.")
 	}
 }


### PR DESCRIPTION
These changes are part of an effort to implement users in the Terraform Grafana provider - https://github.com/terraform-providers/terraform-provider-grafana/issues/51.

### Refactor User Type

Additional fields were added to `User` to capture all available information from the API.

The `UserSearch` type was added. This is structured after user objects returned from the [search users](https://grafana.com/docs/grafana/latest/http_api/user/#search-users) API.

`User` and `UserSearch` are modeled after [`UserProfileDTO ` and `UserSearchHitDTO` in the Grafana codebase](https://github.com/grafana/grafana/blob/0d933b79b7a5e1ba39c5cc8a520a9d93a0d1b602/pkg/models/user.go#L218-L246). Attempting to reuse a single type is going to lead to problems and workarounds like what's being removed from the `UserByEmail` function (where a temporary/alternate struct is created and then cast to a `User`).

### Added Enpoints

* `User` implements the [user by ID](https://grafana.com/docs/grafana/latest/http_api/user/#get-single-user-by-id) API.
* `UserUpdate` implements the [user update](https://grafana.com/docs/grafana/latest/http_api/user/#user-update) API.
* `UpdateUserPassword` implements the [password for user](https://grafana.com/docs/grafana/latest/http_api/admin/#password-for-user) admin API for updating user passwords. This field cannot be updated with `UserUpdate`.
* `UpdateUserPermissions` implements the [user permissions](https://grafana.com/docs/grafana/latest/http_api/admin/#permissions) admin API for updating a user's IsAdmin property. This field also cannot be updated with `UserUpdate`.