### PR TITLE
Add support for providing additional HTTP headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,11 +21,13 @@ type Client struct {
 	key     string
 	baseURL url.URL
 	*http.Client
+	headers map[string]string
 }
 
 //New creates a new grafana client
 //auth can be in user:pass format, or it can be an api key
-func New(auth, baseURL string) (*Client, error) {
+//headers specifies additional HTTP headers, or nil
+func New(auth string, baseURL string, headers map[string]string) (*Client, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
@@ -41,6 +43,7 @@ func New(auth, baseURL string) (*Client, error) {
 		key,
 		*u,
 		cleanhttp.DefaultClient(),
+		headers,
 	}, nil
 }
 
@@ -90,6 +93,11 @@ func (c *Client) newRequest(method, requestPath string, query url.Values, body i
 	}
 	if c.key != "" {
 		req.Header.Add("Authorization", c.key)
+	}
+	if c.headers != nil {
+		for k, v := range c.headers {
+			req.Header.Add(k, v)
+		}
 	}
 
 	if os.Getenv("GF_LOG") != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNew_basicAuth(t *testing.T) {
-	c, err := New("user:pass", "http://my-grafana.com")
+	c, err := New("user:pass", "http://my-grafana.com", nil)
 	if err != nil {
 		t.Errorf("expected error to be nil; got: %s", err.Error())
 	}
@@ -20,7 +20,7 @@ func TestNew_basicAuth(t *testing.T) {
 }
 
 func TestNew_tokenAuth(t *testing.T) {
-	c, err := New("123", "http://my-grafana.com")
+	c, err := New("123", "http://my-grafana.com", nil)
 	if err != nil {
 		t.Errorf("expected error to be nil; got: %s", err.Error())
 	}
@@ -37,7 +37,7 @@ func TestNew_tokenAuth(t *testing.T) {
 }
 
 func TestNew_invalidURL(t *testing.T) {
-	_, err := New("123", "://my-grafana.com")
+	_, err := New("123", "://my-grafana.com", nil)
 
 	expected := "parse \"://my-grafana.com\": missing protocol scheme"
 	if err.Error() != expected {

--- a/mock.go
+++ b/mock.go
@@ -40,6 +40,6 @@ func gapiTestTools(code int, body string) (*mockServer, *Client) {
 		Host:   "my-grafana.com",
 	}
 
-	client := &Client{"my-key", url, httpClient}
+	client := &Client{"my-key", url, httpClient, nil}
 	return mock, client
 }


### PR DESCRIPTION
Sometimes the Grafana server is behind a proxy or application firewall and it is necessary to provide additional HTTP headers to establish a connection, such as authentication tokens or cookies. In general sense these are represented as key-value pairs of strings.