### PR TITLE
Return team id when adding team

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/nytm/go-grafana-api
 
+go 1.15
+
 require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/nytm/go-grafana-api
 
-go 1.15
-
 require (
 	github.com/gobs/pretty v0.0.0-20180724170744-09732c25a95b
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/team.go
+++ b/team.go
@@ -68,9 +68,9 @@ func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
 // Team fetches and returns the Grafana team whose ID it's passed.
 func (c *Client) Team(id int64) (*Team, error) {
 	team := &Team{}
-	err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil, &team)
+	err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil, team)
 	if err != nil {
-		return team, err
+		return nil, err
 	}
 
 	return team, nil

--- a/team.go
+++ b/team.go
@@ -66,8 +66,8 @@ func (c *Client) SearchTeam(query string) (*SearchTeam, error) {
 }
 
 // Team fetches and returns the Grafana team whose ID it's passed.
-func (c *Client) Team(id int64) (Team, error) {
-	team := Team{}
+func (c *Client) Team(id int64) (*Team, error) {
+	team := &Team{}
 	err := c.request("GET", fmt.Sprintf("/api/teams/%d", id), nil, nil, &team)
 	if err != nil {
 		return team, err

--- a/teams_test.go
+++ b/teams_test.go
@@ -135,7 +135,7 @@ func TestTeam(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	expect := &Team{
+	expect := Team{
 		Id:          1,
 		OrgId:       1,
 		Name:        "MyTestTeam",
@@ -158,9 +158,12 @@ func TestAddTeam(t *testing.T) {
 	name := "TestTeam"
 	email := ""
 
-	err := client.AddTeam(name, email)
+	id, err := client.AddTeam(name, email)
 	if err != nil {
 		t.Error(err)
+	}
+	if id == 0 {
+		t.Error("AddTeam returned an invalid id.")
 	}
 }
 

--- a/teams_test.go
+++ b/teams_test.go
@@ -135,7 +135,7 @@ func TestTeam(t *testing.T) {
 
 	t.Log(pretty.PrettyFormat(resp))
 
-	expect := Team{
+	expect := &Team{
 		Id:          1,
 		OrgId:       1,
 		Name:        "MyTestTeam",


### PR DESCRIPTION
This pull request updates the Team code to return the computed id value for newly created teams. This is necessary in support of adding team resource functionality in the terraform provider. See https://github.com/grafana/terraform-provider-grafana/pull/120

Also updated the test to use and validate the newly returned id value. While there, modified the Team code to use a value instead of a pointer. This is more consistent with some of the similar code in org, alert, user... 